### PR TITLE
Make advertised host/port configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides everything you need to run Kafka in Docker.
 
 Why?
 ---
-The main problem with running Kafka in Docker is that it depends on Zookeeper.
+The main hurdle of running Kafka in Docker is that it depends on Zookeeper.
 Compared to other Kafka docker images, this one runs both Zookeeper and Kafka
 in the same container. This means:
 
@@ -15,8 +15,19 @@ in the same container. This means:
 Run
 ---
 
-    docker run -P spotify/kafka
+```bash
+docker run -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`boot2docker ip` --env ADVERTISED_PORT=9092 spotify/kafka
+```
 
+```bash
+export KAFKA=`boot2docker ip`:9092
+kafka-console-producer.sh --broker-list $KAFKA --topic test
+```
+
+```bash
+export ZOOKEEPER=`boot2docker ip`:2181
+kafka-console-consumer.sh --zookeeper $ZOOKEEPER --topic test
+```
 
 In the box
 ---
@@ -36,12 +47,9 @@ Build from Source
     docker build -t spotify/kafka kafka/
 
 
-Notes
+Todo
 ---
-Things are still under development:
 
 * Not particularily optimzed for startup time.
 * Better docs
-* We'd like to be able to configure more things.
-* There should be a prober for Helios.
 

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -1,15 +1,23 @@
 #!/bin/sh
 
 # Optional ENV variables:
-# * HELIOS_PORT_kafka: the external hostname and port, e.g. "awseu3-heliosciagent-a1.spotify.net:9092"
+# * ADVERTISED_HOST: the external ip for the container, e.g. `boot2docker ip`
+# * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
 
-# Set the external host and port
+# Configure advertised host/port if we run in helios
 if [ ! -z "$HELIOS_PORT_kafka" ]; then
     ADVERTISED_HOST=`echo $HELIOS_PORT_kafka | cut -d':' -f 1 | xargs -n 1 dig +short | tail -n 1`
     ADVERTISED_PORT=`echo $HELIOS_PORT_kafka | cut -d':' -f 2`
+fi
 
+# Set the external host and port
+if [ ! -z "$ADVERTISED_HOST" ]; then
+    echo "advertised host: $ADVERTISED_HOST"
     sed -r -i "s/#(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$ADVERTISED_PORT" ]; then
+    echo "advertised port: $ADVERTISED_PORT"
     sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
 fi
 


### PR DESCRIPTION
Enable and document how to configure the advertised host/port. This is required to make things work in boot2docker.