### PR TITLE
Provide environment variables to control log retention time and size.

### DIFF
--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -4,6 +4,8 @@
 # * ADVERTISED_HOST: the external ip for the container, e.g. `boot2docker ip`
 # * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
+# * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
+# * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
 
 # Configure advertised host/port if we run in helios
 if [ ! -z "$HELIOS_PORT_kafka" ]; then
@@ -36,6 +38,16 @@ if [ ! -z "$ZK_CHROOT" ]; then
 
     # configure kafka
     sed -r -i "s/(zookeeper.connect)=(.*)/\1=localhost:2181\/$ZK_CHROOT/g" $KAFKA_HOME/config/server.properties
+fi
+
+# Allow specification of log retention policies
+if [ ! -z "$LOG_RETENTION_HOURS" ]; then
+    echo "log retention hours: $LOG_RETENTION_HOURS"
+    sed -r -i "s/(log.retention.hours)=(.*)/\1=$LOG_RETENTION_HOURS/g" $KAFKA_HOME/config/server.properties
+fi
+if [ ! -z "$LOG_RETENTION_BYTES" ]; then
+    echo "log retention bytes: $LOG_RETENTION_BYTES"
+    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
 fi
 
 # Run Kafka


### PR DESCRIPTION
Extends start-kafka.sh to provide additional properties for optionally configuring the log retention time (hours) and size (bytes).