### PR TITLE
change boot2docker command to docker-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Run
 ---
 
 ```bash
-docker run -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`boot2docker ip` --env ADVERTISED_PORT=9092 spotify/kafka
+docker run -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`docker-machine ip \`docker-machine active\`` --env ADVERTISED_PORT=9092 spotify/kafka
 ```
 
 ```bash
-export KAFKA=`boot2docker ip`:9092
+export KAFKA=`docker-machine ip \`docker-machine active\``:9092
 kafka-console-producer.sh --broker-list $KAFKA --topic test
 ```
 
 ```bash
-export ZOOKEEPER=`boot2docker ip`:2181
+export ZOOKEEPER=`docker-machine ip \`docker-machine active\``:2181
 kafka-console-consumer.sh --zookeeper $ZOOKEEPER --topic test
 ```
 

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Optional ENV variables:
-# * ADVERTISED_HOST: the external ip for the container, e.g. `boot2docker ip`
+# * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
 # * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
 # * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)


### PR DESCRIPTION
I updated README.md because boot2docker is deprecated.

[Releases · boot2docker/boot2docker-cli](https://github.com/boot2docker/boot2docker-cli/releases) 
