### PR TITLE
Support zookeeper.connect parameter $ZK_SERVER in --env

### DIFF
--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -3,6 +3,7 @@
 # Optional ENV variables:
 # * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
 # * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
+# * ZK_SERVER: the zookeeper server and port kafka connects to, e.g "localhost:2181"
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
 # * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
 # * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
@@ -24,6 +25,15 @@ if [ ! -z "$ADVERTISED_PORT" ]; then
     sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
 fi
 
+# Config zookeeper connect
+if [ ! -z "$ZK_SERVER" ]; then
+    echo "zookeeper server: $ZK_SERVER"
+    sed -r -i "s/(zookeeper.connect)=(.*)/\1=$ZK_SERVER/g" $KAFKA_HOME/config/server.properties
+else
+    $ZK_SERVER=localhost:2181
+fi
+
+
 # Set the zookeeper chroot
 if [ ! -z "$ZK_CHROOT" ]; then
     # wait for zookeeper to start up
@@ -38,7 +48,7 @@ if [ ! -z "$ZK_CHROOT" ]; then
     }
 
     # configure kafka
-    sed -r -i "s/(zookeeper.connect)=(.*)/\1=localhost:2181\/$ZK_CHROOT/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/(zookeeper.connect)=(.*)/\1=$ZK_SERVER\/$ZK_CHROOT/g" $KAFKA_HOME/config/server.properties
 fi
 
 # Allow specification of log retention policies


### PR DESCRIPTION
Kafka 0.8.2 doesn't have a high-level rebalanced consumer api,  [pykafka](https://github.com/Parsely/pykafka) with kafka 0.8.2 requires this parameter to rebalance consumer.

Default parameter is `localhost:2181`, if we deploy the image to another server, pykafka won't work.
