### PR TITLE
kafka: Support arbitrary broker settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run
 ---
 
 ```bash
-docker run -p 2181:2181 -p 9092:9092 --env ADVERTISED_HOST=`docker-machine ip \`docker-machine active\`` --env ADVERTISED_PORT=9092 spotify/kafka
+docker run -p 2181:2181 -p 9092:9092 --env KAFKA_CONFIG_ADVERTISED_HOST_NAME=`docker-machine ip \`docker-machine active\`` --env KAFKA_CONFIG_ADVERTISED_PORT=9092 spotify/kafka
 ```
 
 ```bash

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -1,35 +1,30 @@
-#!/bin/sh
+#!/bin/bash
 
-# Optional ENV variables:
-# * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
-# * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
-# * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
-# * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
-# * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
-# * NUM_PARTITIONS: configure the default number of log partitions per topic
+set -o errexit
+set -o nounset
+
+set_setting() {
+  name=$1
+  value=$2
+  file="$KAFKA_HOME/config/server.properties"
+
+  sed -r -i "s/^[#\\s]*($name)[\\s]*=.*/\\1=$value/" "$file"
+  if grep -Pq "^$name=$value\$" "$file"; then
+    echo "$name: updated to '$value'"
+  else
+    echo "$name=$value" >> "$file";
+    echo "$name: added and set to '$value'"
+  fi
+}
+
+env | grep -Po '(?<=^KAFKA_CONFIG_).*' | while IFS='=' read -r name value; do
+  set_setting "$(echo "${name//_/.}" | tr '[:upper:]' '[:lower:]')" "$value"
+done
 
 # Configure advertised host/port if we run in helios
-if [ ! -z "$HELIOS_PORT_kafka" ]; then
-    ADVERTISED_HOST=`echo $HELIOS_PORT_kafka | cut -d':' -f 1 | xargs -n 1 dig +short | tail -n 1`
-    ADVERTISED_PORT=`echo $HELIOS_PORT_kafka | cut -d':' -f 2`
-fi
-
-# Set the external host and port
-if [ ! -z "$ADVERTISED_HOST" ]; then
-    echo "advertised host: $ADVERTISED_HOST"
-    if grep -q "^advertised.host.name" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" $KAFKA_HOME/config/server.properties
-    else
-        echo "advertised.host.name=$ADVERTISED_HOST" >> $KAFKA_HOME/config/server.properties
-    fi
-fi
-if [ ! -z "$ADVERTISED_PORT" ]; then
-    echo "advertised port: $ADVERTISED_PORT"
-    if grep -q "^advertised.port" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
-    else
-        echo "advertised.port=$ADVERTISED_PORT" >> $KAFKA_HOME/config/server.properties
-    fi
+if [ -n "${HELIOS_PORT_kafka:-}" ]; then
+    set_setting advertised.host.name "$(echo "$HELIOS_PORT_kafka" | cut -d':' -f 1 | xargs -n 1 dig +short | tail -n 1)"
+    set_setting advertised.port "$(echo "$HELIOS_PORT_kafka" | cut -d':' -f 2)"
 fi
 
 # Set the zookeeper chroot
@@ -45,30 +40,7 @@ if [ ! -z "$ZK_CHROOT" ]; then
         exit 1
     }
 
-    # configure kafka
-    sed -r -i "s/(zookeeper.connect)=(.*)/\1=localhost:2181\/$ZK_CHROOT/g" $KAFKA_HOME/config/server.properties
-fi
-
-# Allow specification of log retention policies
-if [ ! -z "$LOG_RETENTION_HOURS" ]; then
-    echo "log retention hours: $LOG_RETENTION_HOURS"
-    sed -r -i "s/(log.retention.hours)=(.*)/\1=$LOG_RETENTION_HOURS/g" $KAFKA_HOME/config/server.properties
-fi
-if [ ! -z "$LOG_RETENTION_BYTES" ]; then
-    echo "log retention bytes: $LOG_RETENTION_BYTES"
-    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
-fi
-
-# Configure the default number of log partitions per topic
-if [ ! -z "$NUM_PARTITIONS" ]; then
-    echo "default number of partition: $NUM_PARTITIONS"
-    sed -r -i "s/(num.partitions)=(.*)/\1=$NUM_PARTITIONS/g" $KAFKA_HOME/config/server.properties
-fi
-
-# Enable/disable auto creation of topics
-if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
-    echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
-    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
+    set_setting zookeeper.connect "$ZK_CHROOT"
 fi
 
 # Run Kafka


### PR DESCRIPTION
It's annoying that I can't change most settings. It's trivial to implement such a feature with 15 lines of bash.

I have a bunch of other improvements in my fork, feel free to take a look if you want.