### PR TITLE
support listeners in --env

### DIFF
--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -3,6 +3,7 @@
 # Optional ENV variables:
 # * ADVERTISED_HOST: the external ip for the container, e.g. `docker-machine ip \`docker-machine active\``
 # * ADVERTISED_PORT: the external port for Kafka, e.g. 9092
+# * LISTENERS: configure the listener list e.g. "PLAINTEXT://:9092"
 # * ZK_CHROOT: the zookeeper chroot that's used by Kafka (without / prefix), e.g. "kafka"
 # * LOG_RETENTION_HOURS: the minimum age of a log file in hours to be eligible for deletion (default is 168, for 1 week)
 # * LOG_RETENTION_BYTES: configure the size at which segments are pruned from the log, (default is 1073741824, for 1GB)
@@ -29,6 +30,16 @@ if [ ! -z "$ADVERTISED_PORT" ]; then
         sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
     else
         echo "advertised.port=$ADVERTISED_PORT" >> $KAFKA_HOME/config/server.properties
+    fi
+fi
+
+# Set the listener list
+if [ ! -z "$LISTENERS" ]; then
+    echo "listeners : $LISTENERS"
+    if grep -q "^listeners" $KAFKA_HOME/config/server.properties; then
+        sed -r -i "s/#(listeners)=(.*)/\1=$(echo $LISTENERS | sed -e 's/[\/&]/\\&/g')/g" $KAFKA_HOME/config/server.properties
+    else
+        echo "listeners=$LISTENERS" >> $KAFKA_HOME/config/server.properties
     fi
 fi
 


### PR DESCRIPTION
When using host_port different than 9092 (e.g on Jenkins Server) a message producer keeps getting following error:
"WARN Error while fetching metadata with correlation id 1 : {t1=LEADER_NOT_AVAILABLE} (org.apache.kafka.clients.NetworkClient)"

e.g.
docker run -p 2181:2181 -p 9093:9092 -e AUTO_CREATE_TOPICS=true -e ADVERTISED_HOST=localhost -e ADVERTISED_PORT=9093 --rm spotify/kafka
/opt/kafka/current/bin/kafka-console-producer.sh --broker-list localhost:9093 --topic t1


The LISTENERS configuration allows to use different than default host_port
e.g. 
docker run -p 2181:2181 -p 9093:9093 -e AUTO_CREATE_TOPICS=true -e ADVERTISED_HOST=localhost -e ADVERTISED_PORT=9093 -e LISTENERS="PLAINTEXT://:9093" --rm spotify/kafka