### PR TITLE
Add default advertised host and topic creation

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
     tar xfz /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz -C /opt && \
     rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
 
+ADD scripts/create-topics.sh /usr/bin/create-topics.sh
 ADD scripts/start-kafka.sh /usr/bin/start-kafka.sh
 
 # Supervisor config

--- a/kafka/scripts/create-topics.sh
+++ b/kafka/scripts/create-topics.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+
+if [[ -z "$START_TIMEOUT" ]]; then
+    START_TIMEOUT=600
+fi
+
+start_timeout_exceeded=false
+count=0
+step=10
+while netstat -lnt | awk '$4 ~ /:'$KAFKA_PORT'$/ {exit 1}'; do
+    echo "waiting for kafka to be ready"
+    sleep $step;
+    count=$(expr $count + $step)
+    if [ $count -gt $START_TIMEOUT ]; then
+        start_timeout_exceeded=true
+        break
+    fi
+done
+
+if $start_timeout_exceeded; then
+    echo "Not able to auto-create topic (waited for $START_TIMEOUT sec)"
+    exit 1
+fi
+
+if [[ -n $KAFKA_CREATE_TOPICS ]]; then
+    IFS=','; for topicToCreate in $KAFKA_CREATE_TOPICS; do
+        echo "creating topics: $topicToCreate"
+        IFS=':' read -a topicConfig <<< "$topicToCreate"
+        if [ ${topicConfig[3]} ]; then
+          JMX_PORT='' $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partition ${topicConfig[1]} --topic "${topicConfig[0]}" --config cleanup.policy="${topicConfig[3]}"
+        else
+          JMX_PORT='' $KAFKA_HOME/bin/kafka-topics.sh --create --zookeeper $KAFKA_ZOOKEEPER_CONNECT --replication-factor ${topicConfig[2]} --partition ${topicConfig[1]} --topic "${topicConfig[0]}"
+        fi
+    done
+fi

--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -15,6 +15,10 @@ if [ ! -z "$HELIOS_PORT_kafka" ]; then
 fi
 
 # Set the external host and port
+if [ -z "$ADVERTISED_HOST" ]; then
+    ADVERTISED_HOST=`route -n | awk '/UG[ \t]/{print $2}'`
+fi
+
 if [ ! -z "$ADVERTISED_HOST" ]; then
     echo "advertised host: $ADVERTISED_HOST"
     if grep -q "^advertised.host.name" $KAFKA_HOME/config/server.properties; then
@@ -23,6 +27,7 @@ if [ ! -z "$ADVERTISED_HOST" ]; then
         echo "advertised.host.name=$ADVERTISED_HOST" >> $KAFKA_HOME/config/server.properties
     fi
 fi
+
 if [ ! -z "$ADVERTISED_PORT" ]; then
     echo "advertised port: $ADVERTISED_PORT"
     if grep -q "^advertised.port" $KAFKA_HOME/config/server.properties; then
@@ -70,6 +75,8 @@ if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
     echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
     echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
 fi
+
+create-topics.sh &
 
 # Run Kafka
 $KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties


### PR DESCRIPTION
# Reasons for change

- Need the ability to link things together in docker-compose, and having a default good ADVERTISED_HOST seemed like a good default.
- Create topics becomes laborious if done imperatively, so having it declarative in a `docker-compose.yml` `enviroment` section seems a tad better.

# TODO

- README updates