### PR TITLE
Fix Kafka-image build malfunction

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -4,7 +4,7 @@ FROM java:openjdk-8-jre
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV SCALA_VERSION 2.11
-ENV KAFKA_VERSION 0.10.1.0
+ENV KAFKA_VERSION 0.10.2.1
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
 
 # Install Kafka, Zookeeper and other needed things


### PR DESCRIPTION
I've just changed the Kafka minor version ENV in Dockerfile.  Without this fix, the Dockerfile (and image build pricess) wasn't functional.