### PR TITLE
Fix: ADVERTISED_{HOST,PORT} params are ignored on container restart

### DIFF
--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -18,7 +18,7 @@ fi
 if [ ! -z "$ADVERTISED_HOST" ]; then
     echo "advertised host: $ADVERTISED_HOST"
     if grep -q "^advertised.host.name" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" $KAFKA_HOME/config/server.properties
+        sed -r -i "s/^(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" $KAFKA_HOME/config/server.properties
     else
         echo "advertised.host.name=$ADVERTISED_HOST" >> $KAFKA_HOME/config/server.properties
     fi
@@ -26,7 +26,7 @@ fi
 if [ ! -z "$ADVERTISED_PORT" ]; then
     echo "advertised port: $ADVERTISED_PORT"
     if grep -q "^advertised.port" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
+        sed -r -i "s/^(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
     else
         echo "advertised.port=$ADVERTISED_PORT" >> $KAFKA_HOME/config/server.properties
     fi
@@ -56,7 +56,7 @@ if [ ! -z "$LOG_RETENTION_HOURS" ]; then
 fi
 if [ ! -z "$LOG_RETENTION_BYTES" ]; then
     echo "log retention bytes: $LOG_RETENTION_BYTES"
-    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
 fi
 
 # Configure the default number of log partitions per topic


### PR DESCRIPTION
I noticed that if the container IP changes from container stop to container start (happens frequently if being used in a docker-compose'd environment), kafkas server.properties won't be updated due to a typo:
\# instead of ^ in sed expressions

As a result (if using IP adresses as ADVERTISED_HOST), clients trying to connect will be disconnected and reconnecting to the wrong IP. For a java based client it looks like this:
```
WARN  [org.apache.kafka.clients.NetworkClient] (KafkaJCAClient) Error while fetching metadata with correlation id 15326 : {mytopic=LEADER_NOT_AVAILABLE}
WARN  [org.apache.kafka.clients.NetworkClient] (KafkaJCAClient) Error while fetching metadata with correlation id 15327 : {mytopic=LEADER_NOT_AVAILABLE}
WARN  [org.apache.kafka.clients.NetworkClient] (KafkaJCAClient) Error while fetching metadata with correlation id 15328 : {mytopic=LEADER_NOT_AVAILABLE}
...
```
So if you're using IP adresses in ADVERTISED_HOST like me, containers need to be recreated all the time unless this PR gets merged.