### PR TITLE
Fixes bash syntax

### DIFF
--- a/kafka/scripts/start-kafka.sh
+++ b/kafka/scripts/start-kafka.sh
@@ -9,31 +9,31 @@
 # * NUM_PARTITIONS: configure the default number of log partitions per topic
 
 # Configure advertised host/port if we run in helios
-if [ ! -z "$HELIOS_PORT_kafka" ]; then
-    ADVERTISED_HOST=`echo $HELIOS_PORT_kafka | cut -d':' -f 1 | xargs -n 1 dig +short | tail -n 1`
-    ADVERTISED_PORT=`echo $HELIOS_PORT_kafka | cut -d':' -f 2`
+if [ -n "$HELIOS_PORT_kafka" ]; then
+    ADVERTISED_HOST=$(echo "$HELIOS_PORT_kafka" | cut -d':' -f 1 | xargs -n 1 dig +short | tail -n 1)
+    ADVERTISED_PORT=$(echo "$HELIOS_PORT_kafka" | cut -d':' -f 2)
 fi
 
 # Set the external host and port
-if [ ! -z "$ADVERTISED_HOST" ]; then
+if [ -n "$ADVERTISED_HOST" ]; then
     echo "advertised host: $ADVERTISED_HOST"
-    if grep -q "^advertised.host.name" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" $KAFKA_HOME/config/server.properties
+    if grep -q "^advertised.host.name" "$KAFKA_HOME"/config/server.properties; then
+        sed -r -i "s/#(advertised.host.name)=(.*)/\1=$ADVERTISED_HOST/g" "$KAFKA_HOME"/config/server.properties
     else
-        echo "advertised.host.name=$ADVERTISED_HOST" >> $KAFKA_HOME/config/server.properties
+        echo "advertised.host.name=$ADVERTISED_HOST" >> "$KAFKA_HOME"/config/server.properties
     fi
 fi
-if [ ! -z "$ADVERTISED_PORT" ]; then
+if [ -n "$ADVERTISED_PORT" ]; then
     echo "advertised port: $ADVERTISED_PORT"
-    if grep -q "^advertised.port" $KAFKA_HOME/config/server.properties; then
-        sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" $KAFKA_HOME/config/server.properties
+    if grep -q "^advertised.port" "$KAFKA_HOME"/config/server.properties; then
+        sed -r -i "s/#(advertised.port)=(.*)/\1=$ADVERTISED_PORT/g" "$KAFKA_HOME"/config/server.properties
     else
-        echo "advertised.port=$ADVERTISED_PORT" >> $KAFKA_HOME/config/server.properties
+        echo "advertised.port=$ADVERTISED_PORT" >> "$KAFKA_HOME"/config/server.properties
     fi
 fi
 
 # Set the zookeeper chroot
-if [ ! -z "$ZK_CHROOT" ]; then
+if [ -n "$ZK_CHROOT" ]; then
     # wait for zookeeper to start up
     until /usr/share/zookeeper/bin/zkServer.sh status; do
       sleep 0.1
@@ -46,30 +46,30 @@ if [ ! -z "$ZK_CHROOT" ]; then
     }
 
     # configure kafka
-    sed -r -i "s/(zookeeper.connect)=(.*)/\1=localhost:2181\/$ZK_CHROOT/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/(zookeeper.connect)=(.*)/\1=localhost:2181\/$ZK_CHROOT/g" "$KAFKA_HOME"/config/server.properties
 fi
 
 # Allow specification of log retention policies
-if [ ! -z "$LOG_RETENTION_HOURS" ]; then
+if [ -n "$LOG_RETENTION_HOURS" ]; then
     echo "log retention hours: $LOG_RETENTION_HOURS"
-    sed -r -i "s/(log.retention.hours)=(.*)/\1=$LOG_RETENTION_HOURS/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/(log.retention.hours)=(.*)/\1=$LOG_RETENTION_HOURS/g" "$KAFKA_HOME"/config/server.properties
 fi
-if [ ! -z "$LOG_RETENTION_BYTES" ]; then
+if [ -n "$LOG_RETENTION_BYTES" ]; then
     echo "log retention bytes: $LOG_RETENTION_BYTES"
-    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/#(log.retention.bytes)=(.*)/\1=$LOG_RETENTION_BYTES/g" "$KAFKA_HOME"/config/server.properties
 fi
 
 # Configure the default number of log partitions per topic
-if [ ! -z "$NUM_PARTITIONS" ]; then
+if [ -n "$NUM_PARTITIONS" ]; then
     echo "default number of partition: $NUM_PARTITIONS"
-    sed -r -i "s/(num.partitions)=(.*)/\1=$NUM_PARTITIONS/g" $KAFKA_HOME/config/server.properties
+    sed -r -i "s/(num.partitions)=(.*)/\1=$NUM_PARTITIONS/g" "$KAFKA_HOME"/config/server.properties
 fi
 
 # Enable/disable auto creation of topics
-if [ ! -z "$AUTO_CREATE_TOPICS" ]; then
+if [ -n "$AUTO_CREATE_TOPICS" ]; then
     echo "auto.create.topics.enable: $AUTO_CREATE_TOPICS"
-    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> $KAFKA_HOME/config/server.properties
+    echo "auto.create.topics.enable=$AUTO_CREATE_TOPICS" >> "$KAFKA_HOME"/config/server.properties
 fi
 
 # Run Kafka
-$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/server.properties
+"$KAFKA_HOME"/bin/kafka-server-start.sh "$KAFKA_HOME"/config/server.properties


### PR DESCRIPTION
Fix quoted variables and negated test `-z `resulting in a needless double-negative. You can just use the `-n` operator instead:

```
# Identical tests to verify that a value is assigned
[ ! -z foo ] # Not has no value
[ -n foo ]   # Has value
```